### PR TITLE
Fix escaping es6 template literal

### DIFF
--- a/bin/meta-bump-npm
+++ b/bin/meta-bump-npm
@@ -44,8 +44,8 @@ loop({
         git fetch --tags
         # Get latest tag name
         latestTag=$(git rev-list --tags --max-count=1)
-        [ -n "$latestTag" ] && latestTag=$(git describe --tags $latestTag) && latestTag=${latestTag#"v"} # remove 'v' from latestTag
-        echo "Enter release version (latest is ${latestTag:-0.0.0}): "
+        [ -n "$latestTag" ] && latestTag=$(git describe --tags $latestTag) && latestTag=\${latestTag#"v"} # remove 'v' from latestTag
+        echo "Enter release version (latest is \${latestTag:-0.0.0}): "
         read VERSION
 
         read -p "Releasing $VERSION - are you sure? (y/n)" -n 1 -r
@@ -82,4 +82,3 @@ _.forEach(dependencies, dep => {
         directories: [ dep.targetFolder ]
     });
 });
-

--- a/bin/meta-bump-yarn
+++ b/bin/meta-bump-yarn
@@ -44,8 +44,8 @@ loop({
         git fetch --tags
         # Get latest tag name
         latestTag=$(git rev-list --tags --max-count=1)
-        [ -n "$latestTag" ] && latestTag=$(git describe --tags $latestTag) && latestTag=${latestTag#"v"} # remove 'v' from latestTag
-        echo "Enter release version (latest is ${latestTag:-0.0.0}): "
+        [ -n "$latestTag" ] && latestTag=$(git describe --tags $latestTag) && latestTag=\${latestTag#"v"} # remove 'v' from latestTag
+        echo "Enter release version (latest is \${latestTag:-0.0.0}): "
         read VERSION
 
         read -p "Releasing $VERSION - are you sure? (y/n)" -n 1 -r
@@ -82,4 +82,3 @@ _.forEach(dependencies, dep => {
         directories: [ dep.targetFolder ]
     });
 });
-

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "yarn test",
+    "transpile": "find bin -type f -exec node -c {} \\;",
     "release": "./release.sh"
   },
   "repository": {

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-
 set -e
+
+npm run transpile
 
 # Get new tags from remote
 git fetch --tags


### PR DESCRIPTION
Hi @karol-f and  @patrykzurawik, I just tried out the 0.2.0 version, unfortunately has compilation errors when I run it:

```
meta bump-yarn -h
proj/node_modules/meta-bump/bin/meta-bump-yarn:47
        [ -n "$latestTag" ] && latestTag=$(git describe --tags $latestTag) && latestTag=${latestTag#"v"} # remove 'v' from latestTag
                                                                                          ^^^^^^^^^

SyntaxError: Missing } in template expression
    at Module._compile (internal/modules/cjs/loader.js:895:18)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10)
    at internal/main/run_main_module.js:17:11

```

Upon further investigations, I found it was an issue with the `${latestTag...}` type syntax within the es6 literal. Looking at the evaluation, the `${}` looks like it is to evaluate bash script,  not es6 literal variable, so it would need to be escaped or else it will look for closing tag.

In this PR, i've also added a compile step to try to surface this during release

Can you please review and any chance of getting a patch 0.2.1 release for this ?

Thanks. 